### PR TITLE
Add CLI flags, default NeoVim to PPA, and install LazyGit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,14 @@
 
 ## Project Overview
 
-Ubuntu Server Bootstrap is an opinionated bash script for provisioning Ubuntu 22+ servers with development and DevOps tools. It installs Docker CE, Docker Compose v2, Zsh with Prezto, and a curated set of CLI tools (ripgrep, fd, fzf, ag, tig, htop, byobu, neovim, etc.).
+Ubuntu Server Bootstrap is an opinionated bash script for provisioning Ubuntu 22+ servers with development and DevOps tools. It installs Docker CE, Docker Compose v2, Zsh with Prezto, and a curated set of CLI tools (ripgrep, fd, fzf, ag, tig, htop, byobu, neovim, lazygit, etc.). Supports CLI flags (e.g. `--nvim-deb`, `--help`).
 
 **Supported Ubuntu LTS versions:** 22.04, 24.04 (x86_64 only)
 
 ## Project Structure
 
 ```
-bootstrap.sh       # Main provisioning script (~393 lines)
+bootstrap.sh       # Main provisioning script (~660 lines)
 run-tests.sh       # Test runner - builds Docker images per Ubuntu version
 Dockerfile         # Container definition for testing
 .github/workflows/ci.yaml  # GitHub Actions CI (matrix: 22.04, 24.04)
@@ -25,8 +25,9 @@ Dockerfile         # Container definition for testing
 - Error/debug/SIGINT trap handlers are defined for logging context
 - Variables use `SCREAMING_SNAKE_CASE` and `${VAR}` interpolation (not `$VAR`)
 - Functions are documented with usage, arguments, return values, and examples
-- Utility functions: `log()`, `logError()`, `runCmdAndLog()`, `currentDate()`
+- Utility functions: `log()`, `logError()`, `runCmdAndLog()`, `currentDate()`, `usage()`
 - GitHub API helpers: `getLatestReleaseForRepo()`, `downloadBinaryLatestRelease()`
+- CLI argument parsing via `while`/`case` loop (`--nvim-deb`, `--help`)
 
 ### Installation Pattern
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ubuntu Server Bootstrap
 
-A slightly opinionated and straightforward script to setup base Ubuntu 18+ servers environment with:
+A slightly opinionated and straightforward script to setup base Ubuntu 22+ servers environment with:
 
 - Docker CE
 - [Docker Compose v2](https://github.com/docker/compose)
@@ -8,22 +8,23 @@ A slightly opinionated and straightforward script to setup base Ubuntu 18+ serve
 - ZSH with [Prezto](https://github.com/sorin-ionescu/prezto)
 - Symlinks `python3` to `python` if `python` command is not found
 - Tools:
+  - `build-essential`: Essential build tools (gcc, make, etc.)
   - [`byobu`](https://ubuntu.com/server/docs/tools-byobu): Enhancement to multiplexers like `screen` or `tmux`
   - `curl`
   - [`fd-find`](https://github.com/sharkdp/fd): A simple, fast and user-friendly alternative to 'find'
   - [`fzf`](https://github.com/junegunn/fzf): A command-line fuzzy finder
   - `git`
   - `htop`: Better `top`
-  - `neovim`
+  - [`lazygit`](https://github.com/jesseduffield/lazygit): A simple terminal UI for git commands
+  - [`neovim`](https://neovim.io/): Hyperextensible Vim-based text editor (set as default `vi`/`vim`)
   - [`ripgrep`](https://github.com/BurntSushi/ripgrep): Recursively searches directories for a regex pattern while respecting your gitignore
   - [`silversearcher-ag`](https://github.com/ggreer/the_silver_searcher): A code-searching tool similar to ack, but faster
+  - [SpeedTest CLI](https://github.com/sivel/speedtest-cli)
   - [`tig`](https://jonas.github.io/tig/): CLI Git client
   - `unzip`
   - `vim`
   - `wget`
   - `zip`
-  - [SpaceVim](https://spacevim.org/)
-  - [SpeedTest CLI](https://github.com/sivel/speedtest-cli)
 
 > **This script is intended to be run as `root`**.
 >
@@ -31,7 +32,6 @@ A slightly opinionated and straightforward script to setup base Ubuntu 18+ serve
 
 It's tested with the following Ubuntu LTS versions:
 
-- `20.04`
 - `22.04`
 - `24.04`
 
@@ -49,6 +49,26 @@ Or with `curl` if already installed:
 
 ```bash
 curl -s https://raw.githubusercontent.com/yorch/ubuntu-server-bootstrap/main/bootstrap.sh | bash
+```
+
+### Options
+
+To see all available options:
+
+```bash
+bash bootstrap.sh --help
+```
+
+| Flag | Description |
+|------|-------------|
+| `--nvim-deb` | Install NeoVim from GitHub releases `.deb` package (default: PPA unstable) |
+| `--help` | Show usage information and exit |
+
+To use flags, download the script first:
+
+```bash
+wget -q -O bootstrap.sh https://raw.githubusercontent.com/yorch/ubuntu-server-bootstrap/main/bootstrap.sh
+bash bootstrap.sh --nvim-deb
 ```
 
 This will take a few minutes, after its done, you might want to restart the box in case there is a newer kernel installed that just got installed.


### PR DESCRIPTION
## Summary
- Add CLI argument parsing with `--help` and `--nvim-deb` flags
- Default NeoVim installation to PPA unstable (matching previous main behavior)
- Add `--nvim-deb` flag to opt into installing NeoVim from GitHub releases `.deb` package instead
- Add LazyGit TUI installation from GitHub releases
- Add `build-essential` to apt tools list

## Test plan
- [ ] `bash bootstrap.sh --help` prints usage and exits
- [ ] `bash bootstrap.sh` installs NeoVim from PPA (default)
- [ ] `bash bootstrap.sh --nvim-deb` installs NeoVim from GitHub releases `.deb`
- [ ] `bash bootstrap.sh --unknown` prints error, shows usage, exits non-zero
- [ ] CI passes for ubuntu:22.04 and ubuntu:24.04
- [ ] `nvim --version` works after bootstrap
- [ ] `lazygit --version` works after bootstrap
- [ ] `vi` and `vim` resolve to nvim via alternatives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--nvim-deb` CLI option to choose NeoVim installation source.
  * LazyGit is now installed as part of setup.
  * Added help documentation for available options.

* **Improvements**
  * Added build-essential to installed development tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->