### PR TITLE
Prevent silent hang when dpkg prompts during upgrades

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -21,8 +21,9 @@ LOCALES=(
     "en_US.UTF-8"
 )
 
+export DEBIAN_FRONTEND=noninteractive
 # APT_CMD="apt-get -qq" # -qq includes -y
-APT_CMD="apt-get -y" # -qq includes -y
+APT_CMD="apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
 APT_INSTALL="${APT_CMD} install"
 
 USR_BIN_DIR=/usr/local/bin

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,7 +22,9 @@ LOCALES=(
 )
 
 export DEBIAN_FRONTEND=noninteractive
-# APT_CMD="apt-get -qq" # -qq includes -y
+# Configure apt-get to run non-interactively and handle configuration files safely:
+#   --force-confdef : automatically select the default action for modified configuration files
+#   --force-confold : keep existing configuration files when a conflict is detected
 APT_CMD="apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold"
 APT_INSTALL="${APT_CMD} install"
 


### PR DESCRIPTION
## Summary
- Set `DEBIAN_FRONTEND=noninteractive` to suppress dpkg interactive dialogs
- Add `--force-confdef` and `--force-confold` dpkg options to auto-resolve config file conflicts

## Problem
When `apt-get upgrade` triggers a dpkg configuration prompt (e.g. "keep or replace this config file?"), the script hangs silently. Since `runCmdAndLog` redirects all output to the log file, the user never sees the prompt and has no way to know what caused the stall.

## Test plan
- [ ] Run `bash run-tests.sh ubuntu:24.04` to verify the full bootstrap completes without hanging
- [ ] Verify existing config files are preserved during package upgrades

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated package installation process for more reliable non-interactive deployments.
  * Improved handling of package configuration conflicts during installation procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->