### PR TITLE
Switch Neovim PPA from stable to unstable

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -399,8 +399,8 @@ function stepInstallNeoVim() {
         # Set neovim as default vim
         local NVIM_BIN
         NVIM_BIN="$(command -v nvim)"
-        runCmdAndLog update-alternatives --set vi "${NVIM_BIN}"
-        runCmdAndLog update-alternatives --set vim "${NVIM_BIN}"
+        runCmdAndLog update-alternatives --install /usr/bin/vi vi "${NVIM_BIN}" 110
+        runCmdAndLog update-alternatives --install /usr/bin/vim vim "${NVIM_BIN}" 110
         log "NeoVim installed."
     else
         logStep "NeoVim already installed."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -393,7 +393,7 @@ function stepInstallNeoVim() {
     if ! [ -e "$(command -v nvim)" ]; then
         logStep "Installing NeoVim..."
         # Adds repo for latest neovim version
-        runCmdAndLog add-apt-repository -y ppa:neovim-ppa/stable
+        runCmdAndLog add-apt-repository -y ppa:neovim-ppa/unstable
         runCmdAndLog ${APT_CMD} update
         runCmdAndLog ${APT_INSTALL} neovim
         # Set neovim as default vim


### PR DESCRIPTION
## Summary
- Switch Neovim installation from `ppa:neovim-ppa/stable` to `ppa:neovim-ppa/unstable` to get the latest Neovim builds

## Test plan
- [ ] Run `bash run-tests.sh ubuntu:24.04` to verify Neovim installs from the unstable PPA
- [ ] Confirm `nvim --version` shows a newer version than the stable PPA provides

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Neovim installation source to use unstable releases instead of stable versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->