### PR TITLE
Drop Ubuntu 20.04 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,6 @@ jobs:
     strategy:
       matrix:
         base_image:
-          - "ubuntu:20.04"
           - "ubuntu:22.04"
           - "ubuntu:24.04"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Project Overview
 
-Ubuntu Server Bootstrap is an opinionated bash script for provisioning Ubuntu 18+ servers with development and DevOps tools. It installs Docker CE, Docker Compose v2, Zsh with Prezto, and a curated set of CLI tools (ripgrep, fd, fzf, ag, tig, htop, byobu, neovim, etc.).
+Ubuntu Server Bootstrap is an opinionated bash script for provisioning Ubuntu 22+ servers with development and DevOps tools. It installs Docker CE, Docker Compose v2, Zsh with Prezto, and a curated set of CLI tools (ripgrep, fd, fzf, ag, tig, htop, byobu, neovim, etc.).
 
-**Supported Ubuntu LTS versions:** 20.04, 22.04, 24.04 (x86_64 only)
+**Supported Ubuntu LTS versions:** 22.04, 24.04 (x86_64 only)
 
 ## Project Structure
 
@@ -12,7 +12,7 @@ Ubuntu Server Bootstrap is an opinionated bash script for provisioning Ubuntu 18
 bootstrap.sh       # Main provisioning script (~393 lines)
 run-tests.sh       # Test runner - builds Docker images per Ubuntu version
 Dockerfile         # Container definition for testing
-.github/workflows/ci.yaml  # GitHub Actions CI (matrix: 20.04, 22.04, 24.04)
+.github/workflows/ci.yaml  # GitHub Actions CI (matrix: 22.04, 24.04)
 .zpreztorc         # Zsh Prezto configuration
 .editorconfig      # Editor style rules
 ```
@@ -48,12 +48,11 @@ Each tool follows this pattern:
 Tests are Docker-based. Each supported Ubuntu version builds a container that runs the full bootstrap script:
 
 ```bash
-bash run-tests.sh ubuntu:20.04
 bash run-tests.sh ubuntu:22.04
 bash run-tests.sh ubuntu:24.04
 ```
 
-CI runs all three versions in parallel via GitHub Actions matrix strategy.
+CI runs both versions in parallel via GitHub Actions matrix strategy.
 
 ## Requirements
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -38,7 +38,6 @@ CURL_CMD="curl -sSLf"
 SPINNER_PID=""
 
 UBUNTU_SUPPORTED_VERSIONS=(
-    "20.04"
     "22.04"
     "24.04"
 )

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 BASE_IMAGES=(
-    "ubuntu:20.04"
     "ubuntu:22.04"
     "ubuntu:24.04"
 )


### PR DESCRIPTION
## Summary
- Remove Ubuntu 20.04 from supported versions (EOL April 2025)
- Minimum supported version is now Ubuntu 22.04
- Updated `bootstrap.sh`, `run-tests.sh`, CI matrix, and `AGENTS.md`

## Test plan
- [ ] CI passes for ubuntu:22.04 and ubuntu:24.04

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI pipeline to test on Ubuntu 22.04 and 24.04 only; removed Ubuntu 20.04 from test matrix

* **Documentation**
  * Updated project documentation to reflect supported Ubuntu versions (22.04 and 24.04)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->